### PR TITLE
Add paramater 'solo'

### DIFF
--- a/plugins/docs/dns-module-documentation.md
+++ b/plugins/docs/dns-module-documentation.md
@@ -208,6 +208,16 @@ Module for managing dns records via the api.
     value: 'hello world'
     username: test_user
     password: test_password
+
+- name: Ensure that there is only one A record of test.example.com
+  inwx.collection.dns:
+    domain: example.com
+    type: A
+    record: test
+    value: 127.0.0.1
+    solo: yes
+    username: test_user
+    password: test_password
 ```
 
 ## Options
@@ -308,6 +318,14 @@ options:
             - Required for C(type=SRV).
         type: str
         required: false
+    solo:
+        description:
+            - Wether the record should be the only one for that record name and type.
+            - Only works with `state=present`
+            - This will delete all other records with the same record name and type.
+        type: bool
+        required: false
+        default: false
     state:
         description:
             - Whether the record(s) should exist or not.

--- a/plugins/modules/dns.py
+++ b/plugins/modules/dns.py
@@ -122,6 +122,14 @@ options:
             - Required for C(type=SRV).
         type: str
         required: false
+    solo:
+        description:
+            - Wether the record should be the only one for that record name and type.
+            - Only works with `state=present`
+            - This will delete all other records with the same record name and type.
+        type: bool
+        required: false
+        default: false
     state:
         description:
             - Whether the record(s) should exist or not.
@@ -374,6 +382,16 @@ EXAMPLES = '''
     type: TXT
     record: test
     value: 'hello world'
+    username: test_user
+    password: test_password
+
+- name: Ensure that there is only one A record for test.example.com
+  inwx.collection.dns:
+    domain: example.com
+    type: A
+    record: test
+    value: 127.0.0.1
+    solo: yes
     username: test_user
     password: test_password
 '''


### PR DESCRIPTION
This PR adds the optional parameter `solo` and the corresponding documentation.

With this parameter set, other DNS records sharing the same `fqdn` and `type` will be deleted, leaving only the record intact that should be configured by ansible.

The implementation is analogue to other DNS providers. For example cloudflare: https://docs.ansible.com/ansible/latest/modules/cloudflare_dns_module.html/#parameter-solo

I hope this PR can be of help to you and others.