### PR TITLE
Document TTL limits according to INWX limits

### DIFF
--- a/plugins/modules/dns.py
+++ b/plugins/modules/dns.py
@@ -147,7 +147,7 @@ options:
     ttl:
         description:
             - The TTL to give the new record.
-            - Must be between 3600 and 2,147,483,647 seconds.
+            - Must be between 300 and 864000 seconds.
         type: int
         required: false
         default: 86400


### PR DESCRIPTION
Currently INWX enforces a TTL between 300 and 864000. This is a minor documentation update to reflect that.

Fixes  #6