### PR TITLE
fix examples and linting

### DIFF
--- a/playbooks/examples/dns_set_record.yml
+++ b/playbooks/examples/dns_set_record.yml
@@ -8,8 +8,6 @@
         domain: example.com
         type: A
         record: test
-        value:
-          - 1.2.3.4
-          - 2.3.4.5
+        value: 1.2.3.4
         username: "{{ lookup('env', 'ANSIBLE_INWX_USER') }}"
         password: "{{ lookup('env', 'ANSIBLE_INWX_PASS') }}"

--- a/playbooks/examples/dns_use_2fa.yml
+++ b/playbooks/examples/dns_use_2fa.yml
@@ -8,10 +8,10 @@
         username: "{{ lookup('env', 'ANSIBLE_INWX_USER') }}"
         password: "{{ lookup('env', 'ANSIBLE_INWX_PASS') }}"
         shared_secret: "{{ lookup('env', 'ANSIBLE_INWX_SECRET') }}"
-        register: temp_session_output
+      register: temp_session_output
 
     - name: Set inwx session as fact
-      set_fact:
+      ansible.builtin.set_fact:
         inwx_session: "{{ temp_session_output.result.session }}"
         temp_session_result: # set to nothing
 
@@ -20,6 +20,5 @@
         domain: example.com
         type: A
         record: test
-        value:
-          - 1.2.3.4
+        value: 1.2.3.4
         session: '{{ inwx_session }}'


### PR DESCRIPTION
This PR contains the following:

- Fix value Parameter `value` that needs a string not a list.
- Fix indenting of parameter `register`.
- Fix fqcn for module `set_fact`.
- Fix linting: Added a newline at the end of `playbooks/examples/dns_use_2fa.yml`.